### PR TITLE
minor version bump to address #1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CCT
 Title: Common Covid Tasks
-Version: 0.5.2
+Version: 0.6.0
 Authors@R: 
     person(given = "Adrian",
            family = "Zetner",
@@ -8,7 +8,7 @@ Authors@R:
            email = "adrian.zetner@phac-aspc.gc.ca",
            comment = c(ORCID = "0000-0003-4947-9756"))
 Description: Common Covid Tasks (CCT) provides a one stop shop for functions that support common requests for SARS-CoV-2 information.
-Date: 2023-10-30
+Date: 2023-12-28
 URL: https://github.com/TheZetner/cct,
     https://thezetner.github.io/cct/
 License: Apache License (>= 2)

--- a/man/checkCache.Rd
+++ b/man/checkCache.Rd
@@ -4,25 +4,20 @@
 \alias{checkCache}
 \title{Check Cache vs Current}
 \usage{
-checkCache(overwrite = TRUE, ...)
+checkCache(overwrite = TRUE, network = FALSE, ...)
 }
 \arguments{
-\item{overwrite}{set to false to compare cache to file and return data}
+\item{overwrite}{set to false to compare cache to file and return data without writing}
 
 \item{...}{Pass alternate \code{lineages_url} and \code{aliases_url} to \code{updateHierarchies}}
+
+\item{output}{logical, TRUE for network (produced by fromDFtoNetwork) FALSE for table}
 }
 \value{
-a list with three or more elements
+depending on the value of output
 \itemize{
-\item lineages list with fixed aliases
-\item hierarchy list
-\itemize{
+\item table of lineage hierarchies with fixed aliases
 \item a Node class network object describing the hierarchy of lineages
-\item a table of so-called orphan lineages that call on non-existent parents
-}
-\item file.info output showing most recent update time for cache
-\item new lineages between cache and update
-\item new aliases between cache and update
 }
 }
 \description{

--- a/vignettes/hierarchyfuncs.Rmd
+++ b/vignettes/hierarchyfuncs.Rmd
@@ -13,19 +13,22 @@ vignette: >
 - Will not overwrite cache if update has no new lineages compared to cache
 - The force argument forcibly returns the lineages in the file specified regardless of how it compares to the cache
 - Can supply either `lineages_url` or `aliases_url` to target specific files with `updateHierarchies()`
+- checkCache returns a table of lineage hierarchies by default or a data.tree network with `network = TRUE`
+
+### Table
 
 ```{r}
 library(CCT)
 # Grab an older version
 cachedat <- checkCache(lineages_url = "https://raw.githubusercontent.com/cov-lineages/pango-designation/4b5957e151c10e92cb49e9df904c0b2ea841f3eb/lineage_notes.txt")
 
-purrr::map(cachedat, head)
+head(cachedat)
 ```
 
 
 ```{r}
 # how many lineages?
-nrow(cachedat$lineages)
+nrow(cachedat)
 ```
 
 
@@ -34,8 +37,14 @@ nrow(cachedat$lineages)
 cachedat <- checkCache()
 
 # how many lineages?
-nrow(cachedat$lineages)
+nrow(cachedat)
 ```
+
+### Network
+```{r}
+cachedatNET <- checkCache(network = TRUE)
+```
+
 
 ## Run All in One Line
 - Building this documentation at a time when the master file is broken so linking specifically to my own
@@ -61,9 +70,10 @@ head(l)
 ```
 
 ## From Dataframe to Network
-- Take the dataframe from `updateHierarchies()` and build a node network using [data.tree](https://cran.r-project.org/web/packages/data.tree/vignettes/data.tree.html)
+- Take the dataframe from `updateHierarchies()` or `checkCache(network = FALSE)` and build a node network using [data.tree](https://cran.r-project.org/web/packages/data.tree/vignettes/data.tree.html)
 - Defines the parent-child relationship between each node (lineage)
 - Also returns a table of "orphan" lineages that are missing parents in the table as these break the network and are removed
+- Can replace `ll$network` with `cachedatNET` from above
 ```{r}
 ll <- fromDFtoNetwork(l)
 ll
@@ -74,6 +84,8 @@ ll
 ### Network
 ```{r}
 ancestors <- pullAncestors(ll$network, "BA.5.2", table = FALSE)
+# ancestors <- pullAncestors(cachedatNET, "BA.5.2", table = FALSE)
+
 ancestors
 ```
 


### PR DESCRIPTION
Persistent deprecation message was due to storage of node network object within list in environment. 
Updated checkCache to return either a table (default) or node network instead of a larger list object. 