### PR TITLE
update PA/GD in order to return the expected type of object when missing node

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CCT
 Title: Common Covid Tasks
-Version: 0.6.9000
+Version: 0.7.0
 Authors@R: 
     person(given = "Adrian",
            family = "Zetner",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CCT
 Title: Common Covid Tasks
-Version: 0.6.1
+Version: 0.6.9000
 Authors@R: 
     person(given = "Adrian",
            family = "Zetner",
@@ -8,14 +8,14 @@ Authors@R:
            email = "adrian.zetner@phac-aspc.gc.ca",
            comment = c(ORCID = "0000-0003-4947-9756"))
 Description: Common Covid Tasks (CCT) provides a one stop shop for functions that support common requests for SARS-CoV-2 information.
-Date: 2024-01-18
+Date: 2024-07-09
 URL: https://github.com/TheZetner/cct,
     https://thezetner.github.io/cct/
 License: Apache License (>= 2)
 Encoding: UTF-8
 LazyData: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr
 Imports: 
     data.tree,

--- a/R/lineages.R
+++ b/R/lineages.R
@@ -258,13 +258,13 @@ fromDFtoNetwork <- function(x) {
 #' Get a lineages ancestors out of a `fromDFtoNetwork()`node network.
 #' Vector being TRUE supersedes table being TRUE.
 #' Default return node network.
-#' Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
+#' Nodes not found result in NULL, empty string, or empty df of levelName/level/attribute depending on output being network/vector/table
 #'
 #' @param x node network produce by `fromDFtoNetwork()`
 #' @param node_name Lineage of interest ie. "BA.1"
 #' @param table logical, return subtree or dataframe of level/lineage
 #' @param vector logical, return vector  of lineage names
-#' @param label character, data column to pull, use "name" for levelName
+#' @param attribute character, metadata attribute to use for table/vector output, use "name" for levelName
 #'
 #' @return one of two options depending on table/vector params
 #'  - a Node class network object of the nodes leading to node_name
@@ -276,7 +276,7 @@ pullAncestors <-
            node_name,
            table = FALSE,
            vector = FALSE,
-           label = "lineage") {
+           attribute = "lineage") {
     initial_node <- data.tree::FindNode(x, node_name)
 
     # Export Subtree up to initial_node
@@ -301,7 +301,7 @@ pullAncestors <-
           # Return empty table if node not found
           message("Node not found")
           df <- data.frame(levelName = character(), level = numeric(), col = character())
-          names(df) <- c("levelName", "level", label)
+          names(df) <- c("levelName", "level", attribute)
           df
         } else {
           # Build DF from tree
@@ -309,9 +309,8 @@ pullAncestors <-
             data.tree::as.Node(data.frame(pathString = initial_node$pathString)) %>%
             data.tree::ToDataFrameTree(
               "level",
-              label
+              attribute
             )
-          new_tree$lineage <- stringr::str_split_1(initial_node$pathString, "/")
           new_tree
         }
       }
@@ -323,13 +322,13 @@ pullAncestors <-
 #' Get a lineage's descendants out of a `fromDFtoNetwork()`node network.
 #' Vector being TRUE supersedes table being TRUE.
 #' Default return node network.
-#' Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
+#' Nodes not found result in NULL, empty string, or empty df of levelName/level/attribute depending on output being network/vector/table
 #'
 #' @param x node network produce by `fromDFtoNetwork()`
 #' @param node_name Lineage of interest ie. "BA.1"
 #' @param table logical, return tree as dataframe of level/lineage
 #' @param vector logical, return vector  of lineage names
-#' @param label character, data column to pull, use "name" for network levelName, will error if incorrect
+#' @param attribute character, metadata attribute to use for table/vector output, use "name" for levelName
 #'
 #' @return one of three options depending on table/vector params
 #'  - a Node class network object of the nodes beneath node_name
@@ -342,14 +341,14 @@ getDescendants <-
            node_name,
            table = FALSE,
            vector = FALSE,
-           label = "lineage") {
+           attribute = "lineage") {
     new_tree <- data.tree::FindNode(x, node_name)
 
     if (!vector && !table) {
       new_tree
     } else {
       # Build DF from tree
-      new_tree <- new_tree %>% data.tree::ToDataFrameTree("level", label)
+      new_tree <- new_tree %>% data.tree::ToDataFrameTree("level", attribute)
       if (vector) {
         # Return vector of lineages
         if (nrow(new_tree) == 0) {
@@ -358,7 +357,7 @@ getDescendants <-
           return("")
         } else {
           new_tree %>%
-            dplyr::pull(label) %>%
+            dplyr::pull(attribute) %>%
             return()
         }
       } else {
@@ -366,7 +365,7 @@ getDescendants <-
         if (nrow(new_tree) == 0) {
           message("Node not found")
           df <- data.frame(levelName = character(), level = numeric(), col = character())
-          names(df) <- c("levelName", "level", label)
+          names(df) <- c("levelName", "level", attribute)
           df
         } else {
           new_tree

--- a/man/getDescendants.Rd
+++ b/man/getDescendants.Rd
@@ -4,7 +4,13 @@
 \alias{getDescendants}
 \title{Get Descendants from a Specific Lineage}
 \usage{
-getDescendants(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
+getDescendants(
+  x,
+  node_name,
+  table = FALSE,
+  vector = FALSE,
+  attribute = "lineage"
+)
 }
 \arguments{
 \item{x}{node network produce by \code{fromDFtoNetwork()}}
@@ -15,7 +21,7 @@ getDescendants(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
 
 \item{vector}{logical, return vector  of lineage names}
 
-\item{label}{character, data column to pull, use "name" for network levelName}
+\item{attribute}{character, metadata attribute to use for table/vector output, use "name" for levelName}
 }
 \value{
 one of three options depending on table/vector params
@@ -29,5 +35,5 @@ one of three options depending on table/vector params
 Get a lineage's descendants out of a \code{fromDFtoNetwork()}node network.
 Vector being TRUE supersedes table being TRUE.
 Default return node network.
-Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
+Nodes not found result in NULL, empty string, or empty df of levelName/level/attribute depending on output being network/vector/table
 }

--- a/man/getDescendants.Rd
+++ b/man/getDescendants.Rd
@@ -4,7 +4,7 @@
 \alias{getDescendants}
 \title{Get Descendants from a Specific Lineage}
 \usage{
-getDescendants(x, node_name, table = FALSE, vector = FALSE)
+getDescendants(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
 }
 \arguments{
 \item{x}{node network produce by \code{fromDFtoNetwork()}}
@@ -14,17 +14,20 @@ getDescendants(x, node_name, table = FALSE, vector = FALSE)
 \item{table}{logical, return tree as dataframe of level/lineage}
 
 \item{vector}{logical, return vector  of lineage names}
+
+\item{label}{character, data column to pull, use "name" for network levelName}
 }
 \value{
-one of three options depending on table and vector params
+one of three options depending on table/vector params
 \itemize{
 \item a Node class network object of the nodes beneath node_name
 \item a table from the node network with level and lineage names
-\item a vector of lineage names
+\item a vector of lineage/node names
 }
 }
 \description{
 Get a lineage's descendants out of a \code{fromDFtoNetwork()}node network.
 Vector being TRUE supersedes table being TRUE.
 Default return node network.
+Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
 }

--- a/man/pullAncestors.Rd
+++ b/man/pullAncestors.Rd
@@ -4,7 +4,13 @@
 \alias{pullAncestors}
 \title{Pull Ancestors from a Specific Lineage}
 \usage{
-pullAncestors(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
+pullAncestors(
+  x,
+  node_name,
+  table = FALSE,
+  vector = FALSE,
+  attribute = "lineage"
+)
 }
 \arguments{
 \item{x}{node network produce by \code{fromDFtoNetwork()}}
@@ -15,7 +21,7 @@ pullAncestors(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
 
 \item{vector}{logical, return vector  of lineage names}
 
-\item{label}{character, data column to pull, use "name" for levelName}
+\item{attribute}{character, metadata attribute to use for table/vector output, use "name" for levelName}
 }
 \value{
 one of two options depending on table/vector params
@@ -29,5 +35,5 @@ one of two options depending on table/vector params
 Get a lineages ancestors out of a \code{fromDFtoNetwork()}node network.
 Vector being TRUE supersedes table being TRUE.
 Default return node network.
-Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
+Nodes not found result in NULL, empty string, or empty df of levelName/level/attribute depending on output being network/vector/table
 }

--- a/man/pullAncestors.Rd
+++ b/man/pullAncestors.Rd
@@ -4,7 +4,7 @@
 \alias{pullAncestors}
 \title{Pull Ancestors from a Specific Lineage}
 \usage{
-pullAncestors(x, node_name, table = FALSE, vector = FALSE)
+pullAncestors(x, node_name, table = FALSE, vector = FALSE, label = "lineage")
 }
 \arguments{
 \item{x}{node network produce by \code{fromDFtoNetwork()}}
@@ -14,17 +14,20 @@ pullAncestors(x, node_name, table = FALSE, vector = FALSE)
 \item{table}{logical, return subtree or dataframe of level/lineage}
 
 \item{vector}{logical, return vector  of lineage names}
+
+\item{label}{character, data column to pull, use "name" for levelName}
 }
 \value{
-one of two options depending on table param
+one of two options depending on table/vector params
 \itemize{
 \item a Node class network object of the nodes leading to node_name
 \item a table from the node network with level and lineage names
-\item a vector of lineage names
+\item a vector of lineage/node names
 }
 }
 \description{
 Get a lineages ancestors out of a \code{fromDFtoNetwork()}node network.
 Vector being TRUE supersedes table being TRUE.
 Default return node network.
+Nodes not found result in NULL, empty string, or empty df of levelName/level/label depending on output being network/vector/table
 }

--- a/vignettes/hierarchyfuncs.Rmd
+++ b/vignettes/hierarchyfuncs.Rmd
@@ -47,11 +47,12 @@ cachedatNET <- checkCache(network = TRUE)
 
 
 ## Run All in One Line
-- Building this documentation at a time when the master file is broken so linking specifically to my own
 
 ```{r}
+# In case newest version breaks use: lineages_url = "https://raw.githubusercontent.com/TheZetner/pango-designation/master/lineage_notes.txt"
+
 hierarchy <-
-  CCT::updateHierarchies(lineages_url = "https://raw.githubusercontent.com/TheZetner/pango-designation/master/lineage_notes.txt") %>% CCT::fromDFtoNetwork()
+  CCT::updateHierarchies() %>% CCT::fromDFtoNetwork()
 
 hierarchy
 ```
@@ -102,7 +103,6 @@ ancestors <- pullAncestors(ll$network, "BA.5.2", table = TRUE, vector = TRUE)
 ancestors
 ```
 
-
 ## Get all the Descendants of a Node
 
 ### Network
@@ -121,12 +121,10 @@ getDescendants(ll$network, "BF.7", table = TRUE)
 getDescendants(ll$network, "BF.7", table = TRUE, vector = TRUE)
 ```
 
-
 ## Make YAML Watchlist (for Augur)
 ```{r}
 getDescendants(ll$network, "BF.7", vector = TRUE) %>% makeWatchlist()
 ```
-
 
 ## Download Variants table from CoVariants
 ```{r}
@@ -134,8 +132,103 @@ vars <- getVariants()
 vars
 ```
 
-
 ## Expand Variants Table to Include all Children
 ```{r}
 expandChildren(head(vars), ll$network)
 ```
+
+# Custom Hierarchies
+- CCT can also examine custom hierarchies for descendants and ancestors
+- This capacity is limited at the moment but can easily provide the same functionality as above to work with yaml-defined hierarchies.
+
+## Create a Randomly Nested YAML
+```{r ch1}
+# Random YAML
+yaml <- "fruit:\n"
+depth <- ""
+maxdepth <- 1
+deepest <- stringr::fruit[1]
+for(i in stringr::fruit){
+  flip <- round(runif(1, 0, 1))
+  if(flip == 1){
+    flip <- round(runif(1, 0, 1))
+    if(flip == 1){
+      depth <- paste0(depth, "  ")
+      if(stringr::str_count(depth, "  ") > maxdepth){
+        maxdepth <- stringr::str_count(depth, "  ")
+        deepest <- i
+      }
+    }
+  }else{
+    depth <- "  "
+  }
+  yaml <- paste0(yaml,
+                 paste0(depth, i, ":\n"))
+}
+cat(yaml)
+```
+
+Now that the hierarchy is defined in the above yaml text we can load it and convert it into a data.tree node network. A YAML file can also be supplied using the commented text.
+
+```{r ch2}
+
+# To load a file
+# yaml::read_yaml(yaml) %>%
+#   data.tree::as.Node(interpretNullAsList = TRUE)
+
+hier <- yaml::yaml.load(yaml) %>%
+  data.tree::as.Node(interpretNullAsList = TRUE)
+
+str(hier)
+
+```
+
+The deepest element of that fake yaml is **`r deepest`** let's use that as an example.
+
+## Examining the Custom Hierarchy
+
+Pull ancestors of deepest and return a node.
+```{r ch3}
+y <- pullAncestors(x = hier, 
+              node_name = deepest)
+
+str(y)
+```
+
+Print it (looks like a table)
+```{r ch4}
+y
+```
+
+Return an actual table. Note the lineage column of `NA`.
+```{r ch5}
+y <- pullAncestors(x = hier, 
+              node_name = deepest,
+              table = T)
+y
+```
+
+The attribute parameter is used to query the data in `pullAncestors` and can refer to any built in attributes of the [data.tree node network](https://cran.r-project.org/web/packages/data.tree/data.tree.pdf) or custom metadata.
+```{r ch6}
+y <- pullAncestors(x = hier, 
+              node_name = deepest,
+              table = T,
+              attribute = "name")
+y
+```
+
+
+```{r ch7}
+v <- pullAncestors(x = hier, 
+              node_name = deepest,
+              vector = T,
+              attribute = "name")
+v
+```
+
+Get descendants in a similar way as above.
+```{r ch8}
+getDescendants(hier, v[3], attribute = "name")
+
+```
+


### PR DESCRIPTION
When searching for a node with `pullAncestors` or `getDescendants` if the node is missing a NULL will be returned by default, an empty vector for `vector=T` and an empty dataframe for `table = T`. Minor guard rails have also been added to replace inscrutable error messages when searching for non-existent nodes.

A new parameter has been added to each of the above functions `attribute`. This allows the resulting vector/table/node network to use other metadata than "lineage" when reading from data.tree networks. The most likely use of this will be in reading custom hierarchies from yaml where the protected data.tree label "name" can be substituted for "lineage" and retrieve metadata from the network. 

